### PR TITLE
Now support Mode Hanzi. Fix bug in Mode Kanji.

### DIFF
--- a/segno/consts.py
+++ b/segno/consts.py
@@ -21,6 +21,7 @@ MODE_STRUCTURED_APPEND = 0x3
 MODE_BYTE = 0x4
 MODE_ECI = 0x7
 MODE_KANJI = 0x8
+MODE_HANZI = 0xD
 
 # Micro QR Code uses different mode indicators
 # ISO/IEC 18004:2015(E) -- Table 2 — Mode indicators for QR Code (page 23)
@@ -66,12 +67,14 @@ ERROR_LEVEL_TO_MICRO_MAPPING = {
 
 DEFAULT_BYTE_ENCODING = 'iso-8859-1'
 KANJI_ENCODING = 'shift_jis'
+HANZI_ENCODING = 'gb2312'
 
 MODE_MAPPING = {
     'numeric': MODE_NUMERIC,
     'alphanumeric': MODE_ALPHANUMERIC,
     'byte': MODE_BYTE,
     'kanji': MODE_KANJI,
+    'hanzi': MODE_HANZI,
 }
 
 ERROR_MAPPING = {
@@ -163,6 +166,7 @@ SUPPORTED_MODES = {
     MODE_BYTE: (None, VERSION_M3, VERSION_M4),
     MODE_ECI: (None,),
     MODE_KANJI: (None, VERSION_M3, VERSION_M4),
+    MODE_HANZI: (None,),
 }
 
 # ISO/IEC 18004:2015(E) -- Table 2 — Mode indicators for QR Code (page 23)
@@ -197,6 +201,10 @@ CHAR_COUNT_INDICATOR_LENGTH = {
         VERSION_RANGE_01_09:  8,
         VERSION_RANGE_10_26: 10,
         VERSION_RANGE_27_40: 12,                               VERSION_M3: 3, VERSION_M4: 4},
+    MODE_HANZI: {
+        VERSION_RANGE_01_09:  8,
+        VERSION_RANGE_10_26: 10,
+        VERSION_RANGE_27_40: 12},
 }
 
 

--- a/segno/encoder.py
+++ b/segno/encoder.py
@@ -1082,7 +1082,7 @@ def make_segment(data, mode, encoding=None):
         if _PY2:  # pragma: no cover
             segment_data = [ord(b) for b in segment_data]
         # Note: len(segment.data)! segment.data_length = len(segment.data) / 2!!
-        for i in range(0, char_count, 2):
+        for i in range(0, len(segment_data), 2):
             code = (segment_data[i] << 8) | segment_data[i + 1]
             if 0xa1a1 <= code <= 0xaafe:
                 # For characters with GB2312 values from A1A1HEX to AAFEHEX:
@@ -1102,7 +1102,7 @@ def make_segment(data, mode, encoding=None):
         # ISO/IEC 18004:2015(E) -- 7.4.6 Kanji mode (page 29)
         if _PY2:  # pragma: no cover
             segment_data = [ord(b) for b in segment_data]
-        for i in range(0, char_count, 2):
+        for i in range(0, len(segment_data), 2):
             code = (segment_data[i] << 8) | segment_data[i + 1]
             if 0x8140 <= code <= 0x9ffc:
                 # 1. a) For characters with Shift JIS values from 8140HEX to 9FFCHEX:

--- a/tests/test_hanzi.py
+++ b/tests/test_hanzi.py
@@ -30,7 +30,7 @@ def test_default_hanzi_mode():
 def test_force_hanzi_mode():
     qr = segno.make('书读百遍其义自现', mode='hanzi')
     assert 'hanzi' == qr.mode
-    assert '1-H' == qr.designator
+    assert '1-M' == qr.designator
 
 
 def test_default_hanzi_mode2():
@@ -42,13 +42,13 @@ def test_default_hanzi_mode2():
 def test_force_hanzi_mode2():
     qr = segno.make('大江东去，浪淘尽，千古风流人物。故垒西边，人道是，三国周郎赤壁。乱石穿空，惊涛拍岸，卷起千堆雪。江山如画，一时多少豪杰。遥想公瑾当年，小乔初嫁了，雄姿英发。羽扇纶巾，谈笑间，樯橹灰飞烟灭。故国神游，多情应笑我，早生华发。人生如梦，一尊还酹江月。', mode='hanzi')
     assert 'hanzi' == qr.mode
-    assert '5-L' == qr.designator
+    assert '9-L' == qr.designator
 
 
 def test_force_hanzi_mode_and_encoding():
     qr = segno.make('书读百遍其义自现', mode='hanzi', encoding='gb2312')
     assert 'hanzi' == qr.mode
-    assert '1-H' == qr.designator
+    assert '1-M' == qr.designator
 
 
 def test_default_utf8_encoder():

--- a/tests/test_hanzi.py
+++ b/tests/test_hanzi.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 - 2020 -- Shi Yan
+# All rights reserved.
+#
+# License: BSD License
+#
+"""\
+Tests against Hanzi encoding.
+"""
+from __future__ import absolute_import, unicode_literals
+import pytest
+import segno
+from segno import consts, encoder
+
+
+def test_detect_hanzi():
+    qr = segno.make('汉字')
+    assert 'byte' == qr.mode
+    assert qr.is_micro
+    assert 'M3-M' == qr.designator
+
+
+def test_default_hanzi_mode():
+    qr = segno.make('书读百遍其义自现')
+    assert 'byte' == qr.mode
+    assert '2-M' == qr.designator
+
+
+def test_force_hanzi_mode():
+    qr = segno.make('书读百遍其义自现', mode='hanzi')
+    assert 'hanzi' == qr.mode
+    assert '1-H' == qr.designator
+
+
+def test_default_hanzi_mode2():
+    qr = segno.make('大江东去，浪淘尽，千古风流人物。故垒西边，人道是，三国周郎赤壁。乱石穿空，惊涛拍岸，卷起千堆雪。江山如画，一时多少豪杰。遥想公瑾当年，小乔初嫁了，雄姿英发。羽扇纶巾，谈笑间，樯橹灰飞烟灭。故国神游，多情应笑我，早生华发。人生如梦，一尊还酹江月。')
+    assert 'byte' == qr.mode
+    assert '12-L' == qr.designator
+
+
+def test_force_hanzi_mode2():
+    qr = segno.make('大江东去，浪淘尽，千古风流人物。故垒西边，人道是，三国周郎赤壁。乱石穿空，惊涛拍岸，卷起千堆雪。江山如画，一时多少豪杰。遥想公瑾当年，小乔初嫁了，雄姿英发。羽扇纶巾，谈笑间，樯橹灰飞烟灭。故国神游，多情应笑我，早生华发。人生如梦，一尊还酹江月。', mode='hanzi')
+    assert 'hanzi' == qr.mode
+    assert '5-L' == qr.designator
+
+
+def test_force_hanzi_mode_and_encoding():
+    qr = segno.make('书读百遍其义自现', mode='hanzi', encoding='gb2312')
+    assert 'hanzi' == qr.mode
+    assert '1-H' == qr.designator
+
+
+def test_default_utf8_encoder():
+    qr = encoder.encode('书读百遍其义自现')
+    assert 1 == len(qr.segments)
+    segment = qr.segments[0]
+    assert consts.MODE_BYTE == segment.mode
+    assert 24 == segment.char_count
+
+
+def test_force_hanzi_encoder():
+    qr = encoder.encode('书读百遍其义自现', mode='hanzi')
+    assert 1 == len(qr.segments)
+    segment = qr.segments[0]
+    assert consts.MODE_HANZI == segment.mode
+    assert 8 == segment.char_count
+
+
+def test_detect_hanzi_encoder2():
+    # detect as utf8
+    qr = encoder.encode('汉字')
+    assert 1 == len(qr.segments)
+    segment = qr.segments[0]
+    assert consts.MODE_BYTE == segment.mode
+    assert 6 == segment.char_count
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
I have added the Mode Hanzi with GB2312 subset, this will make QR more compact.
Also, there is a [bug in Mode Kanji on the return length](https://github.com/heuer/segno/blob/4ea7de580cb5b5552fb0501d26f15c0cace668be/segno/encoder.py#L1010). Each Kanji/Hanzi character is represented by 2 bytes code in GB2312 standard. So the length of character should be the length of string, or the length of data divided by 2.