### PR TITLE
Geo: Remove trailing period

### DIFF
--- a/segno/helpers.py
+++ b/segno/helpers.py
@@ -449,7 +449,7 @@ def make_geo_data(lat, lng):
     :rtype: str
     """
     def float_to_str(f):
-        return '{0:.8f}'.format(f).rstrip('.0')
+        return '{0:.8f}'.format(f).rstrip('0').rstrip('.')
 
     return 'geo:{0},{1}'.format(float_to_str(lat), float_to_str(lng))
 

--- a/segno/helpers.py
+++ b/segno/helpers.py
@@ -449,7 +449,7 @@ def make_geo_data(lat, lng):
     :rtype: str
     """
     def float_to_str(f):
-        return '{0:.8f}'.format(f).rstrip('0')
+        return '{0:.8f}'.format(f).rstrip('.0')
 
     return 'geo:{0},{1}'.format(float_to_str(lat), float_to_str(lng))
 


### PR DESCRIPTION
When an integer is passed to `make_geo_data()`, the trailing zeroes are removed, but not the period. Because of this, it can't be scanned on iOS.