### PR TITLE
GS1 QR mode support

### DIFF
--- a/segno/__init__.py
+++ b/segno/__init__.py
@@ -22,7 +22,7 @@ __all__ = ('make', 'make_qr', 'make_micro', 'make_sequence', 'QRCode',
 
 
 def make(content, error=None, version=None, mode=None, mask=None, encoding=None,
-         eci=False, micro=None, boost_error=True):
+         eci=False, micro=None, boost_error=True, gs1=None):
     """\
     Creates a (Micro) QR Code.
 
@@ -136,11 +136,11 @@ def make(content, error=None, version=None, mode=None, mask=None, encoding=None,
     :rtype: QRCode
     """
     return QRCode(encoder.encode(content, error, version, mode, mask, encoding,
-                                 eci, micro, boost_error=boost_error))
+                                 eci, micro, boost_error=boost_error,gs1=gs1))
 
 
 def make_qr(content, error=None, version=None, mode=None, mask=None,
-            encoding=None, eci=False, boost_error=True):
+            encoding=None, eci=False, boost_error=True, gs1=None):
     """\
     Creates a QR code (never a Micro QR code).
 
@@ -149,7 +149,7 @@ def make_qr(content, error=None, version=None, mode=None, mask=None,
     :rtype: QRCode
     """
     return make(content, error=error, version=version, mode=mode, mask=mask,
-                encoding=encoding, eci=eci, micro=False, boost_error=boost_error)
+                encoding=encoding, eci=eci, micro=False, boost_error=boost_error,gs1=gs1)
 
 
 def make_micro(content, error=None, version=None, mode=None, mask=None,

--- a/segno/consts.py
+++ b/segno/consts.py
@@ -106,6 +106,7 @@ GS_ALPHANUMERIC = 0x25
 FNC1_MAPPING = {
     'first': FNC1_FIRST,
     'second': FNC1_SECOND,
+    # 'uri': None
 }
 
 #

--- a/segno/consts.py
+++ b/segno/consts.py
@@ -93,6 +93,21 @@ ERROR_MAPPING = {
     'H': ERROR_LEVEL_H,
 }
 
+# ISO/IEC 18004:2015(E) -- 7.4.8.2
+
+FNC1_FIRST = 0x5
+FNC1_SECOND = 0x9
+
+GS_BYTES = 0x1D
+# % character
+GS_ALPHANUMERIC = 0x25
+
+
+FNC1_MAPPING = {
+    'first': FNC1_FIRST,
+    'second': FNC1_SECOND,
+}
+
 #
 # ISO/IEC 18004:2015(E) -- 7.3.2 Extended Channel Interpretation (ECI) mode (page 20)
 #

--- a/tests/test_gs1.py
+++ b/tests/test_gs1.py
@@ -9,10 +9,47 @@ qr.show()
 
 # https://www.gs1jp.org/assets/img/pdf/GS1_General_Specifications.pdf
 
-digits 0 to 9
+# https://ref.gs1.org/ai/j
+AI_DATA_MAPPING = {
+    21: "N2+x..20"
+}
 
-A-ZeroDivisionError
-#   [# - /]
+GS1_CHARACTER_SET_82 = [
+    
+]
+
+#  page 155
+# n implied decimal point position
+# N numeric digit
+# X any character in figure 7.11-1 character set 82
+# N3 3 numeric digits, predefined length
+# X3 3 characters, fixed length
+# N..3 up to 3 numeric digits
+# X..3 up to 3 characters in figure 7.11-1
+# DD must be filled 
+
+AI_MAPPING = {
+    21: "N2+X..20"
+}
 
 
+def generate_gs1(string):
+    left_b_split=string.split("[",)
+    if left_b_split[0]:
+        raise ValueError(f'"string" must start with an AI in brackets "[]"')
+    ai_b_data=left_b_split[1:]
+    elements=[]
+    for i in range(len(ai_b_data)):
+        try:
+            ai,data=ai_b_data[i].split("]")
+        except:
+            raise ValueError(f'"string" contains open AI bracket')
+        if not ai.isdecimal():
+            raise ValueError("AI must be a whole number")
+        if not data.isalnum():
+            raise ValueError("Data must only contain characters 0-9, A-Z, and (#-/)")
+        print(ai, data)
+        elements.append((ai,data))
+    print(elements)
 
+generate_gs1("[21]00[21]00")

--- a/tests/test_gs1.py
+++ b/tests/test_gs1.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append(r"C:\Users\Willis\Desktop\segno\segno")
+# import sys
+# sys.path.append(r"C:\Users\Willis\Desktop\segno\segno")
 
 
 import segno
@@ -10,46 +10,46 @@ qr.show()
 # https://www.gs1jp.org/assets/img/pdf/GS1_General_Specifications.pdf
 
 # https://ref.gs1.org/ai/j
-AI_DATA_MAPPING = {
-    21: "N2+x..20"
-}
+# AI_DATA_MAPPING = {
+#     21: "N2+x..20"
+# }
 
-GS1_CHARACTER_SET_82 = [
-    
-]
+# GS1_CHARACTER_SET_82 = [
 
-#  page 155
-# n implied decimal point position
-# N numeric digit
-# X any character in figure 7.11-1 character set 82
-# N3 3 numeric digits, predefined length
-# X3 3 characters, fixed length
-# N..3 up to 3 numeric digits
-# X..3 up to 3 characters in figure 7.11-1
-# DD must be filled 
+# ]
 
-AI_MAPPING = {
-    21: "N2+X..20"
-}
+# #  page 155
+# # n implied decimal point position
+# # N numeric digit
+# # X any character in figure 7.11-1 character set 82
+# # N3 3 numeric digits, predefined length
+# # X3 3 characters, fixed length
+# # N..3 up to 3 numeric digits
+# # X..3 up to 3 characters in figure 7.11-1
+# # DD must be filled 
+
+# AI_MAPPING = {
+#     21: "N2+X..20"
+# }
 
 
-def generate_gs1(string):
-    left_b_split=string.split("[",)
-    if left_b_split[0]:
-        raise ValueError(f'"string" must start with an AI in brackets "[]"')
-    ai_b_data=left_b_split[1:]
-    elements=[]
-    for i in range(len(ai_b_data)):
-        try:
-            ai,data=ai_b_data[i].split("]")
-        except:
-            raise ValueError(f'"string" contains open AI bracket')
-        if not ai.isdecimal():
-            raise ValueError("AI must be a whole number")
-        if not data.isalnum():
-            raise ValueError("Data must only contain characters 0-9, A-Z, and (#-/)")
-        print(ai, data)
-        elements.append((ai,data))
-    print(elements)
+# def generate_gs1(string):
+#     left_b_split=string.split("[",)
+#     if left_b_split[0]:
+#         raise ValueError(f'"string" must start with an AI in brackets "[]"')
+#     ai_b_data=left_b_split[1:]
+#     elements=[]
+#     for i in range(len(ai_b_data)):
+#         try:
+#             ai,data=ai_b_data[i].split("]")
+#         except:
+#             raise ValueError(f'"string" contains open AI bracket')
+#         if not ai.isdecimal():
+#             raise ValueError("AI must be a whole number")
+#         if not data.isalnum():
+#             raise ValueError("Data must only contain characters 0-9, A-Z, and (#-/)")
+#         print(ai, data)
+#         elements.append((ai,data))
+#     print(elements)
 
-generate_gs1("[21]00[21]00")
+# generate_gs1("[21]00[21]00")

--- a/tests/test_gs1.py
+++ b/tests/test_gs1.py
@@ -1,0 +1,18 @@
+import sys
+sys.path.append(r"C:\Users\Willis\Desktop\segno\segno")
+
+
+import segno
+
+qr=segno.make("2100",version=1,gs1="first")
+qr.show()
+
+# https://www.gs1jp.org/assets/img/pdf/GS1_General_Specifications.pdf
+
+digits 0 to 9
+
+A-ZeroDivisionError
+#   [# - /]
+
+
+


### PR DESCRIPTION
The segno library lacks GS1 QR mode support in ISO/IEC 18004 7.4.8.2.
AI verification is not included, but this should help the GS1 progress in segno.

Generate a GS1 QR using the gs1 parameter, implied 1st position Function 1.
![image](https://github.com/user-attachments/assets/a4abc944-75de-4e65-b878-41e2892cb788)

Generated QR code scans with Cognex, AI(21) and data(00).
![image](https://github.com/user-attachments/assets/f854bd0b-390e-49cd-a408-d98640cd9808)