### PR TITLE
Remove obsolete entry from pdf ref table

### DIFF
--- a/segno/writers.py
+++ b/segno/writers.py
@@ -698,11 +698,11 @@ def write_pdf(matrix, matrix_size, out, scale=1, border=None, dark='#000',
         writestr(f'{len(object_pos)} 0 obj <</CreationDate(D:{creation_date})'
                  f'/Producer({CREATOR})/Creator({CREATOR})\r\n>>\r\nendofbj\r\n')
         object_pos.append(f.tell())
-        xref_location = f.tell()
-        writestr(f'xref\r\n0 {len(object_pos) + 1}\r\n0000000000 65535 f\r\n')
-        for pos in object_pos:
+        writestr(f'xref\r\n0 {len(object_pos)}\r\n0000000000 65535 f\r\n')
+        for pos in object_pos[:-1]:
             writestr(f'{pos:010d} {0:05d} n\r\n')
-        writestr(f'trailer <</Size {len(object_pos) + 1}/Root 1 0 R/Info 5 0 R>>\r\n')
+        writestr(f'trailer <</Size {len(object_pos)}/Root 1 0 R/Info 5 0 R>>\r\n')
+        xref_location = object_pos[-1]
         writestr(f'startxref\r\n{xref_location}\r\n%%EOF\r\n')
 
 

--- a/segno/writers.py
+++ b/segno/writers.py
@@ -696,7 +696,7 @@ def write_pdf(matrix, matrix_size, out, scale=1, border=None, dark='#000',
         write(b'\r\nendstream\r\nendobj\r\n')
         object_pos.append(f.tell())
         writestr(f'{len(object_pos)} 0 obj <</CreationDate(D:{creation_date})'
-                 f'/Producer({CREATOR})/Creator({CREATOR})\r\n>>\r\nendofbj\r\n')
+                 f'/Producer({CREATOR})/Creator({CREATOR})\r\n>>\r\nendobj\r\n')
         object_pos.append(f.tell())
         writestr(f'xref\r\n0 {len(object_pos)}\r\n0000000000 65535 f\r\n')
         for pos in object_pos[:-1]:


### PR DESCRIPTION
Before this change, an additional entry for a non-existing object has been created inside the xref table (pointing to the start of the xreftable itself). This caused issues when editing the created pdf e.g. with pypdf, pdftk, or PyMuPDF.